### PR TITLE
Disable `EntityItemMixin` if ItemPhysic (fork) is loaded

### DIFF
--- a/src/main/java/com/fuzs/aquaacrobatics/mixinplugin/Mixins.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/mixinplugin/Mixins.java
@@ -19,7 +19,6 @@ public enum Mixins {
         .setPhase(Phase.EARLY)
         .addMixinClasses(
             "minecraft.EntityBoatMixin",
-            "minecraft.EntityItemMixin",
             "minecraft.EntityPlayerMixin",
             "minecraft.EntityPlayerMPMixin",
             "minecraft.EntityMixin",
@@ -46,8 +45,14 @@ public enum Mixins {
             "minecraft.client.EntityOtherPlayerMPMixin",
             "minecraft.client.PlayerControllerMPMixin")),
 
+    EntityItem(new Builder(" EntityItem").addTargetedMod(TargetedMod.VANILLA)
+        .addExcludedMod(TargetedMod.ITEMPHYSIC)
+        .setSide(Side.BOTH)
+        .setPhase(Phase.EARLY)
+        .addMixinClasses("minecraft.EntityItemMixin")),
+
     BlockGrass(new Builder(" BlockGrass").addTargetedMod(TargetedMod.VANILLA)
-        .addExcludedMod(TargetedMod.Hodgepodge)
+        .addExcludedMod(TargetedMod.HODGEPODGE)
         .setSide(Side.BOTH)
         .setPhase(Phase.EARLY)
         .addMixinClasses("minecraft.BlockGrassMixin"))

--- a/src/main/java/com/fuzs/aquaacrobatics/mixinplugin/TargetedMod.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/mixinplugin/TargetedMod.java
@@ -3,7 +3,10 @@ package com.fuzs.aquaacrobatics.mixinplugin;
 public enum TargetedMod {
 
     VANILLA("Minecraft", null),
-    Hodgepodge("Hodgepodge", "com.mitchej123.hodgepodge.core.HodgepodgeCore", "hodgepodge"),;
+    HODGEPODGE("Hodgepodge", "com.mitchej123.hodgepodge.core.HodgepodgeCore", "hodgepodge"),
+    ITEMPHYSIC("ItemPhysic", "com.creativemd.itemphysic.asm.ItemPhysicEarlyMixins", "itemphysic"),
+
+    ;
 
     /** The "name" in the @Mod annotation */
     public final String modName;


### PR DESCRIPTION
Disables `EntityItemMixin` if [ItemPhysic Legacy Unofficial](https://github.com/kotmatross28729/ItemPhysic-Legacy-Unofficial) is loaded 

ItemPhysic already implements its own item floating system. However, aquaacrobatics mixin is always applied, even when the corresponding option is disabled

Because of this, with ItemPhysic installed, items start to levitate:


https://github.com/user-attachments/assets/f9ddbe1a-7cc3-4b54-96e9-93cecb2d701a

And this is what it usually looks like:


https://github.com/user-attachments/assets/54c98335-1649-42c2-ab82-07dbc94e158c

